### PR TITLE
feat: 토큰 재발급 로직 개선 및 서비스 문구 수정

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,21 +17,23 @@ const Page = () => {
   if (!shouldRender) return null;
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh)] px-4 text-center relative">
-      <div className="font-semibold text-gray-900 z-10 transform">
-        <div className="font-semibold text-xl sm:text-2xl md:text-3xl xl:text-4xl">
-          백지에서 시작하는 진정한 학습,
+    <div className="flex flex-col items-center justify-center min-h-[calc(100vh)] px-4 text-center relative break-keep space-y-0 sm:space-y-2">
+      <div className="font-semibold text-gray-900 z-10 transform tracking-wider space-y-4">
+        <div className="font-semibold text-gray-700 text-3xl sm:text-3xl xl:text-4xl">
+          <span className='block sm:inline'>AI 학습 서비스</span>
+          <span className='block sm:inline mt-2 sm:mt-0 bg-gradient-to-r from-primary-500 to-secondary-500 bg-clip-text text-transparent sm:ml-4'>타뷸라(TABULA)</span>
         </div>
-        <div className="font-semibold text-xl sm:text-2xl md:text-3xl xl:text-4xl mt-1 sm:mt-2 lg:mt-4 mb-2 sm:mb-3 lg:mb-4">
-          TABULA와 함께하세요!
+        <div className="font-semibold text-xl sm:text-3xl xl:text-4xl mt-1 sm:mt-2 lg:mt-4 mb-2 sm:mb-3 lg:mb-4">
+          백지학습을 더 쉽고 효과적으로!
         </div>
       </div>
       <div
         className="mt-4 text-gray-500 z-10 transformtext-sm sm:text-base lg:text-md
-                      max-w-xs sm:max-w-md lg:max-w-2xl"
+                  max-w-xs sm:max-w-md lg:max-w-2xl tracking-wide"
       >
-        틀린 부분과 부족한 부분에 대한 맞춤 피드백을 제공하여 쉽게 백지학습을 할
-        수 있도록 도와줍니다.
+        AI 채점과 피드백으로 부족한 부분을 보완해 자기주도 학습의 완성을 돕습니다.{" "}
+        <br className="hidden lg:block" />
+        스스로 배우고 성장하는 즐거움을 경험해 보세요.
       </div>
       <div className="flex flex-col sm:flex-row gap-4 sm:gap-8 mt-16 sm:mt-8 z-10 transform">
         <Button

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -7,9 +7,8 @@ export const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 export const BASE_URL_AI = process.env.NEXT_PUBLIC_AI_API_URL;
 
 export const END_POINT = {
-  // authReissue: `/v1/auth/reissue`,
   // authIsuue: `/v1/auth/issue`,
-  authIssue: `/v1/auth/reissue`,
+  authReissue: `/v1/auth/reissue`,
   guestLogin: `/v1/auth/guest`,
   workspaceList: `/v1/spaces/`,
   folderList: `/v1/folders`,
@@ -51,7 +50,7 @@ export const AxiosAIInstanceFormData = axios.create({
 const addAccessToken = (config: InternalAxiosRequestConfig) => {
   const accessToken = AuthStore.getState().accessToken;
   if (accessToken && config.headers) {
-    config.headers.set('Authorization', `Bearer ${accessToken}`);
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
   }
   return config;
 };
@@ -73,8 +72,19 @@ const addAccessToken = (config: InternalAxiosRequestConfig) => {
 //   );
 // }
 
-// let isRefreshing = false;
-// let refreshFailCount = 0
+let isRefreshing = false;
+let failedQueue: any[] = [];
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
 
 const handleTokenRefresh = (instance: ReturnType<typeof axios.create>) => {
   instance.interceptors.response.use(
@@ -83,14 +93,29 @@ const handleTokenRefresh = (instance: ReturnType<typeof axios.create>) => {
       const errorData = error.response?.data as any;
       const originalRequest = error.config as any;
 
-      if (
+      if (errorData?.error?.code == 'SECURITY_401_1') {
+        const { addToast } = useToastStore.getState();
+        AuthStore.getState().logout();
+        window.location.href = '/';
+        addToast('로그인 정보가 올바르지 않습니다. 다시 로그인해주세요.');
+        return Promise.reject(error);
+      }
+      else if (
         errorData?.error?.code == 'SECURITY_401_2' &&
         !originalRequest._isRetry
-        // !isRefreshing &&
-        // refreshFailCount < 2
       ) {
+        if (isRefreshing) {
+          return new Promise((resolve, reject) => {
+            failedQueue.push({ resolve, reject })
+          }).then((token) => {
+            originalRequest.headers['Authorization'] = `Bearer ${token}`;
+            return instance(originalRequest);
+          })
+          .catch((err) => Promise.reject(err));
+        }
+        
         originalRequest._isRetry = true;
-        // isRefreshing = true;
+        isRefreshing = true;
 
         try {
           const authState = AuthStore.getState();
@@ -113,18 +138,17 @@ const handleTokenRefresh = (instance: ReturnType<typeof axios.create>) => {
 
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
 
+          processQueue(null, newAccessToken)
+
           return instance(originalRequest);
         } catch (e) {
-          // refreshFailCount++;
+          processQueue(e, null)
           AuthStore.getState().logout();
           window.location.href = '/'; // 추후 로그인 페이지 생기면 교체
-          // const { addToast } = useToastStore.getState();
-          // addToast('세션이 만료되어 로그아웃합니다. 다시 로그인 해주세요.');
           return Promise.reject(e);
+        } finally {
+          isRefreshing = false;
         }
-        // finally {
-        // isRefreshing = false;
-        // }
       }
       return Promise.reject(error);
     },

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -13,7 +13,7 @@ export const postAuth = async (code: string) => {
 
 export const postReissue = async (refreshToken: string) => {
   const response = await AxiosInstance.post(
-    END_POINT.authIssue,
+    END_POINT.authReissue,
     // 수정
     {},
     {


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 <!--이슈번호를 작성해주세요 e.g. #11 -->
- close #88 

## 📋 작업 내용
기존에 reissue가 무한요청이 간다는 버그가 있어 이를 해결하려함

- _isRetry 플래그
  - 같은 요청이 재시도되면 _isRetry로 막아 동일 요청이 계속 reissue를 트리거하지 않음
- catch 블록에서 강제 종료
  - postReissue가 실패하면 logout() + window.location.href = '/'를 실행하여 새 토큰을 받지 못하면 로그아웃
- isRefreshing + failedQueue 패턴
  - 여러 요청이 동시에 401을 받아도 첫번째 요청만 refresh 시도
  - 나머지는 queue에 걸려있다가 새 토큰을 받아오면 한꺼번에 재시도

서비스 문구 수정
  - 랜딩페이지 문구 수정 (반응형 구현)
<img src="https://github.com/user-attachments/assets/59b0e6ee-a389-4f63-847c-c3074f9c9757" width="600"/> <img src="https://github.com/user-attachments/assets/5c17d81b-b086-4098-a8bd-d0332b4d46a0" width="300"/>






