### PR TITLE
feat: 가이드 확인하기 텍스트 버튼형 인터렉션으로 변경

### DIFF
--- a/frontend/app/subject/page.tsx
+++ b/frontend/app/subject/page.tsx
@@ -1,6 +1,11 @@
+'use client';
 import SubjectList from "@/components/Subject/SubjectList"
+import useRedirectGuest from "@/hooks/common/useRedirectGuest"
 
 const page = () => {
+  const { loginType } = useRedirectGuest();
+  if (loginType == null || loginType === 'guest') return null;
+
   return (
     <div className="px-2 sm:px-6 md:px-10 lg: px-16 xl:px-24 py-30">
       <SubjectList />

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -23,7 +23,6 @@ export const AxiosInstance = axios.create({
     'Content-Type': 'application/json',
     Accept: 'application/json',
     withCredentials: true,
-    "ngrok-skip-browser-warning": "true",
   },
   timeout: 10000,
 });
@@ -140,7 +139,6 @@ const handleTokenRefresh = (instance: ReturnType<typeof axios.create>) => {
           }
 
           const data = await postReissue(refreshToken);
-          console.log('[reissue response]', data);
           const newAccessToken = data.response.accessToken;
           const newRefreshToken = data.response.refreshToken;
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -23,6 +23,17 @@ export const AxiosInstance = axios.create({
     'Content-Type': 'application/json',
     Accept: 'application/json',
     withCredentials: true,
+    "ngrok-skip-browser-warning": "true",
+  },
+  timeout: 10000,
+});
+
+export const AxiosTemp = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    withCredentials: true,
   },
   timeout: 10000,
 });
@@ -93,6 +104,9 @@ const handleTokenRefresh = (instance: ReturnType<typeof axios.create>) => {
       const errorData = error.response?.data as any;
       const originalRequest = error.config as any;
 
+      if (originalRequest.url?.includes(END_POINT.authReissue)) {
+        return Promise.reject(error);
+      }
       if (errorData?.error?.code == 'SECURITY_401_1') {
         const { addToast } = useToastStore.getState();
         AuthStore.getState().logout();
@@ -126,6 +140,7 @@ const handleTokenRefresh = (instance: ReturnType<typeof axios.create>) => {
           }
 
           const data = await postReissue(refreshToken);
+          console.log('[reissue response]', data);
           const newAccessToken = data.response.accessToken;
           const newRefreshToken = data.response.refreshToken;
 

--- a/frontend/src/api/login.ts
+++ b/frontend/src/api/login.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance, END_POINT } from '.';
+import { AxiosInstance, AxiosTemp, END_POINT } from '.';
 
 export const postAuth = async (code: string) => {
   const response = await AxiosInstance.post(
@@ -12,7 +12,7 @@ export const postAuth = async (code: string) => {
 };
 
 export const postReissue = async (refreshToken: string) => {
-  const response = await AxiosInstance.post(
+  const response = await AxiosTemp.post(
     END_POINT.authReissue,
     // 수정
     {},

--- a/frontend/src/components/Workspace/StudyLog/LearningFile.tsx
+++ b/frontend/src/components/Workspace/StudyLog/LearningFile.tsx
@@ -22,7 +22,7 @@ const LearningFile = ({ fileName }: LearningFileProps) => {
         </p>
         <p>백지 학습시에는 2분할로 나눠서 작성해주세요.</p>
         <p>자세한 예시는{' '}
-          <span onClick={openModal} className="font-medium hover:text-primary-600 cursor-pointer transition">
+          <span onClick={openModal} className="font-medium hover:text-primary-600 cursor-pointer underline underline-offset-2 transition">
             'Tabula 사용법 알아보기'
           </span>
           {' '}를 참고해주세요 ☺️

--- a/frontend/src/components/Workspace/StudyLog/LearningFile.tsx
+++ b/frontend/src/components/Workspace/StudyLog/LearningFile.tsx
@@ -1,11 +1,13 @@
+import GuideModal from '@/components/Home/GuideModal';
 import SelectedFileItem from '@/components/Workspace/LearningFileUpload/SelectedFileItem';
 import ChatBubble from '@/components/Workspace/StudyLog/ChatBubble';
-
+import useModal from '@/hooks/common/useModal';
 interface LearningFileProps {
   fileName: string;
 }
 
 const LearningFile = ({ fileName }: LearningFileProps) => {
+  const { isModalOpen, openModal, closeModal } = useModal()
   return (
     <div className="w-[70%] lg:w-[60%]">
       <ChatBubble isUser={true}>
@@ -19,11 +21,18 @@ const LearningFile = ({ fileName }: LearningFileProps) => {
           학습 과정 중 막히는 부분이 있다면 ‘키워드 확인하기' 를 이용해주세요!
         </p>
         <p>백지 학습시에는 2분할로 나눠서 작성해주세요.</p>
-        <p>자세한 예시는 'Tabula 사용법 알아보기'를 참고해주세요 ☺️</p>
+        <p>자세한 예시는{' '}
+          <span onClick={openModal} className="font-medium hover:text-primary-600 cursor-pointer transition">
+            'Tabula 사용법 알아보기'
+          </span>
+          {' '}를 참고해주세요 ☺️
+        </p>
         <br />
         <p>이제 학습 결과물을 올려볼까요?✨</p>
         <p>또렷한 글씨, 스캔본·전자 필기본일수록 인식률이 높아집니다.</p>
       </ChatBubble>
+
+      {isModalOpen && <GuideModal isModalOpen={isModalOpen} closeModal={closeModal}/>}
     </div>
   );
 };

--- a/frontend/src/hooks/common/useRedirectGuest.ts
+++ b/frontend/src/hooks/common/useRedirectGuest.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { AuthStore } from '@/stores/authStore';
+
+export default function useRedirectGuest() {
+  const router = useRouter();
+  const { loginType } = AuthStore();
+
+  useEffect(() => {
+    if (loginType == null) return;
+
+    if (loginType === 'guest') {
+      router.replace('/');
+    }
+  }, [loginType, router]);
+
+  return { loginType };
+}


### PR DESCRIPTION
## ⚠️ 연관된 이슈 번호 <!--이슈번호를 작성해주세요 e.g. #11 -->
- close #100 

## 📋 작업 내용
- 가이드 확인하기 텍스트 버튼형 인터렉션으로 변경 (클릭시 모달창 생성)
  | 기본 | 호버시 |
  |------|------|
  |<img width="527" height="155" alt="스크린샷 2025-10-13 오후 1 26 36" src="https://github.com/user-attachments/assets/2bca5938-0ea6-43ba-bd26-df9d99c211e2" />|<img width="495" height="132" alt="스크린샷 2025-10-13 오후 1 28 00" src="https://github.com/user-attachments/assets/e20f0392-6021-41a3-88d9-2aaa9640718a" />|

- 게스트 모드에서 폴더페이지 접근시 랜딩페이지로 리다이렉트
  - (카카오 로그인 한 상태에서 다시 게스트 로그인 했을때 폴더로 접근이 돼서 발생하던 문제)

- reissue axios 인터셉터 분리하여 중복 호출 방지
  - 기존에는 postReissue가 AxiosInstance를 통해 handleTokenRefresh 인터셉터를 다시 트리거함
  - -> reissue 요청이 자기 자신을 재호출하여 무한 루프 상태 발생
  - -> AxiosTemp 인스턴스로 분리하여 인터셉터 분리하여 해결